### PR TITLE
Observations data not displayed in the Observations tab

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -30,7 +30,7 @@ export default function Home() {
 		getObservations(params)
 			.then((response) => {
 				console.log("response", response);
-				setObservations(response.data);
+				setObservations(response.data.data);
 			})
 			.catch((error) => {
 				console.error("Error fetching observations:", error);


### PR DESCRIPTION
Before:
The data exists (checked by the console) but this data is not shown in the Observation tab.

<img width="1509" alt="Screenshot 2024-03-22 at 13 23 18" src="https://github.com/Ovok-User/hello-world/assets/948279/b7e155fd-1ce8-4fc9-af65-c79b47a72ebb">

After fix:

<img width="1475" alt="Screenshot 2024-03-22 at 14 28 28" src="https://github.com/Ovok-User/hello-world/assets/948279/6f88b28a-041c-4956-8c89-a8081704a443">




